### PR TITLE
updated names and made alb logging optional

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,3 +1,10 @@
+locals {
+  access_log_storage = {
+    bucket = var.alb_access_logs_bucket
+    prefix = "alb/${var.name}-lb"
+  }
+}
+
 # TODO(ilya_isakov): change backend protocol to HTTPS
 module "aws_alb" {
   source  = "terraform-aws-modules/alb/aws"
@@ -11,10 +18,7 @@ module "aws_alb" {
   vpc_id             = var.vpc_id
   subnets            = var.private_subnet_ids
 
-  access_logs = {
-    bucket = var.alb_access_logs_bucket
-    prefix = "alb/${var.name}-lb"
-  }
+  access_logs = var.alb_access_logs_bucket != "" ? local.access_log_storage: {}
 
   target_groups = [
     {

--- a/alb.tf
+++ b/alb.tf
@@ -18,7 +18,7 @@ module "aws_alb" {
   vpc_id             = var.vpc_id
   subnets            = var.private_subnet_ids
 
-  access_logs = var.alb_access_logs_bucket != "" ? local.access_log_storage: {}
+  access_logs = var.alb_access_logs_bucket != "" ? local.access_log_storage : {}
 
   target_groups = [
     {

--- a/data_sync_generic.tf
+++ b/data_sync_generic.tf
@@ -11,13 +11,13 @@ data "aws_iam_policy_document" "datasync-role-policy" {
 }
 
 resource "aws_iam_role" "dags-datasync-task-role" {
-  name               = "DagsDatasyncTaskRole"
+  name               = "${var.name}-dags-datasync-task-role"
   path               = "/airflow_module/"
   assume_role_policy = data.aws_iam_policy_document.datasync-role-policy.json
 }
 
 resource "aws_iam_policy" "dags-datasync-task-policy" {
-  name        = "dags-datasync-task-policy"
+  name        = "${var.name}-dags-datasync-task-policy"
   path        = "/airflow_module/"
   description = "Policy allowing Datasync to copy DAGs from s3 to EFS"
 

--- a/ecs_container_instances.tf
+++ b/ecs_container_instances.tf
@@ -3,14 +3,12 @@ data "template_file" "user_data" {
   template = file("${path.module}/templates/user_data.sh")
 
   vars = {
-    cluster_name         = "${var.name}-cluster"
-    dag_s3_bucket        = var.dag_s3_bucket
-    dag_s3_key           = var.dag_s3_key
-    rclone_secret_key_id = var.rclone_secret_key_id
-    rclone_secret_key    = var.rclone_secret_key
-    region               = var.region
-    custom_user_data     = var.custom_user_data
-    airflow_home         = var.airflow_home
+    cluster_name     = "${var.name}-cluster"
+    dag_s3_bucket    = var.dag_s3_bucket
+    dag_s3_key       = var.dag_s3_key
+    region           = var.region
+    custom_user_data = var.custom_user_data
+    airflow_home     = var.airflow_home
   }
 }
 

--- a/efs.tf
+++ b/efs.tf
@@ -2,6 +2,7 @@ module "efs" {
   source  = "cloudposse/efs/aws"
   version = "0.22.0"
 
+  name            = var.name
   region          = var.region
   vpc_id          = var.vpc_id
   subnets         = var.private_subnet_ids

--- a/elasticache.tf
+++ b/elasticache.tf
@@ -17,7 +17,7 @@ resource "aws_elasticache_subnet_group" "this" {
 }
 
 resource "aws_elasticache_parameter_group" "this" {
-  name   = "af-cache-params"
+  name   = "${var.name}-cache-params"
   family = "redis5.0"
 
   parameter {

--- a/iam.tf
+++ b/iam.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "instance-assume-role-policy" {
 }
 
 resource "aws_iam_role" "airflow-task-definition-execution-role" {
-  name               = "airflowTaskDefinitionExecutionRole"
+  name               = "${var.name}-task-definition-execution-role"
   path               = "/airflow_module/"
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy.json
   tags               = var.tags
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "system-manager-policy-attachment" {
 }
 
 resource "aws_iam_instance_profile" "airflow-task-definition-execution-profile" {
-  name = "airflow-task-definition-execution-profile"
+  name = "${var.name}-task-definition-execution-profile"
   role = aws_iam_role.airflow-task-definition-execution-role.name
 }
 

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "sg_airflow_internal" {
-  name        = "sg_airflow_internal"
+  name        = "${var.name}-sg-airflow-internal"
   description = "Security group for Airflow internal traffic (Elasticache, RDS, ENIs, Datasync task, EFS mount targets)."
   vpc_id      = var.vpc_id
 

--- a/variables.tf
+++ b/variables.tf
@@ -133,20 +133,9 @@ variable "airflow_image" {
   default     = "puckel/docker-airflow:1.10.9"
 }
 
-variable "rclone_secret_key" {
-  type        = string
-  description = "A key used to copy DAGs from the bucket to container instance."
-}
-
 variable "airflow_fernet_key" {
   type        = string
   description = "A key used to encrypt connection's passwords in AF metadata database."
-}
-
-### user_data
-variable "rclone_secret_key_id" {
-  type        = string
-  description = "A key_id used to copy DAGs from the bucket to container instance."
 }
 
 variable "dag_s3_bucket" {
@@ -241,6 +230,7 @@ variable "lb_target_container_port" {
 variable "alb_access_logs_bucket" {
   type        = string
   description = "An s3 bucket, where to store logs from alb."
+  default     = ""
 }
 
 ### ecs_service


### PR DESCRIPTION
- Removed rclone credentials as they are not needed anymore
- updated names so that multiple deployments in same env are possible
- Made alb logging optional (user should be able to deploy without too much extra effort; so nice to have but optional)